### PR TITLE
Specify dependency versions in gemspec

### DIFF
--- a/formatter-date.gemspec
+++ b/formatter-date.gemspec
@@ -1,28 +1,30 @@
 # encoding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'formatter/date/version'
 
-require File.expand_path('../lib/formatter/date/version', __FILE__)
+Gem::Specification.new do |spec|
+  spec.name          = 'formatter-date'
+  spec.version       = Formatter::Date::VERSION
+  spec.authors       = ['Terje Larsen']
+  spec.email         = 'terlar@gmail.com'
+  spec.summary       = 'Date formatter with time zone support'
+  spec.description   = spec.summary
+  spec.homepage      = 'https://github.com/terlar/formatter-date'
+  spec.license       = 'MIT'
 
-Gem::Specification.new do |gem|
-  gem.name          = 'formatter-date'
-  gem.version       = Formatter::Date::VERSION.dup
-  gem.authors       = ['Terje Larsen']
-  gem.email         = 'terlar@gmail.com'
-  gem.description   = 'Date formatter with time zone support'
-  gem.summary       = gem.description
-  gem.homepage      = 'https://github.com/terlar/formatter-date'
-  gem.license       = 'MIT'
+  spec.files         = `git ls-files`.split($RS)
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = %w(lib)
+  spec.extra_rdoc_files = %w(LICENSE README.md)
 
-  gem.require_paths = %w(lib)
-  gem.files         = `git ls-files`.split($RS)
-  gem.test_files    = gem.files.grep(/^test\//)
-  gem.extra_rdoc_files = %w(LICENSE README.md)
+  spec.required_ruby_version = '>= 1.9.3'
 
-  gem.required_ruby_version = '>= 1.9.3'
+  spec.add_runtime_dependency 'tzinfo', '~> 1.2.2'
 
-  gem.add_runtime_dependency 'tzinfo'
-
-  gem.add_development_dependency 'bundler', '~> 1.6'
-  gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'minitest'
-  gem.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'minitest', '~> 5.8'
+  spec.add_development_dependency 'rubocop', '~> 0.35'
 end

--- a/lib/formatter/date.rb
+++ b/lib/formatter/date.rb
@@ -94,10 +94,10 @@ module Formatter
       case format
       when Symbol
         if format_method? format
-          return -> datetime { datetime.send format, fraction }
+          return ->(datetime) { datetime.send format, fraction }
         end
       when String
-        return -> datetime { datetime.strftime format }
+        return ->(datetime) { datetime.strftime format }
       end
 
       fail ArgumentError, "invalid value for format: #{format.inspect}"


### PR DESCRIPTION
It is good practice to track this, in case we would rely on some functionality
that gets changed between versions both for development dependencies and runtime
dependencies.
